### PR TITLE
Update DESCRIPTION, remove snftool from github

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,8 @@ Suggests:
     rmarkdown,
     kableExtra
 Remotes: 
-    github::maxconway/SNFtool@master, github::danro9685/CIMLR@R, github::Lothelab/CMScaller@master, github::davidgohel/officer@master
+    github::danro9685/CIMLR@R, github::Lothelab/CMScaller@master, github::davidgohel/officer@master
+# github::maxconway/SNFtool@master this code is outdated, with use CRAN
 Imports: 
     CIMLR,
     ClassDiscovery,


### PR DESCRIPTION
maxconway/SNFtool@master depends on heatmap.plus which has been archived on CRAN.

Using SNFtool from CRAN works.